### PR TITLE
Use the type/enum name as api id

### DIFF
--- a/src/schema/create-content-type-input.js
+++ b/src/schema/create-content-type-input.js
@@ -17,9 +17,7 @@ function createContentTypeInputFromObject(
   let position = 1;
   const contentTypeInput: ContentTypeInput = {
     name: generateLabel(name.value),
-    apiId: name.value
-      .replace(/([a-z])([A-Z])/g, g => `${g[0]}_${g[1]}`)
-      .toUpperCase(),
+    apiId: name.value,
     description: definition.description
       ? definition.description.value.trim()
       : '',
@@ -49,9 +47,7 @@ function createContentTypeInputFromEnum(
 
   return {
     name: generateLabel(name.value),
-    apiId: name.value
-      .replace(/([a-z])([A-Z])/g, g => `${g[0]}_${g[1]}`)
-      .toUpperCase(),
+    apiId: name.value,
     isEnum: true,
     isHashmap: true,
     description: definition.description

--- a/src/schema/create-content-type-input.test.js
+++ b/src/schema/create-content-type-input.test.js
@@ -16,7 +16,7 @@ describe('createContentTypeInput function', () => {
       const input = simpleContentTypes[0];
 
       const output = {
-        apiId: 'AUTHOR',
+        apiId: 'Author',
         name: 'Author',
         description: 'Test description',
         fields: [
@@ -53,7 +53,7 @@ describe('createContentTypeInput function', () => {
       expect(createContentTypeInput(input)).toEqual(output);
     });
 
-    it('uses underscore for multipart camel case names', () => {
+    it('leaves the type name as is', () => {
       const schema = `
         type CamelCaseName implements SimpleContentType {
           field1: String
@@ -62,7 +62,7 @@ describe('createContentTypeInput function', () => {
       const { simpleContentTypes } = parse(schema);
       const input = simpleContentTypes[0];
 
-      expect(createContentTypeInput(input).apiId).toEqual('CAMEL_CASE_NAME');
+      expect(createContentTypeInput(input).apiId).toEqual('CamelCaseName');
     });
 
     it('generates a label from the name', () => {
@@ -90,7 +90,7 @@ describe('createContentTypeInput function', () => {
       const input = singletonContentTypes[0];
 
       const output = {
-        apiId: 'HOMEPAGE',
+        apiId: 'Homepage',
         name: 'Homepage',
         description: 'Test description',
         fields: [
@@ -110,7 +110,7 @@ describe('createContentTypeInput function', () => {
       expect(createContentTypeInput(input)).toEqual(output);
     });
 
-    it('uses underscore for multipart camel case names', () => {
+    it('leaves the type name as is', () => {
       const schema = `
           type CamelCaseName implements SingletonContentType {
             field1: String
@@ -119,7 +119,7 @@ describe('createContentTypeInput function', () => {
       const { singletonContentTypes } = parse(schema);
       const input = singletonContentTypes[0];
 
-      expect(createContentTypeInput(input).apiId).toEqual('CAMEL_CASE_NAME');
+      expect(createContentTypeInput(input).apiId).toEqual('CamelCaseName');
     });
 
     it('generates a label from the name', () => {
@@ -147,7 +147,7 @@ describe('createContentTypeInput function', () => {
       const input = embeddableContentTypes[0];
 
       const output = {
-        apiId: 'PICTURE',
+        apiId: 'Picture',
         name: 'Picture',
         description: 'Test description',
         fields: [
@@ -167,7 +167,7 @@ describe('createContentTypeInput function', () => {
       expect(createContentTypeInput(input)).toEqual(output);
     });
 
-    it('uses underscore for multipart camel case names', () => {
+    it('leaves the type name as is', () => {
       const schema = `
           type CamelCaseName implements EmbeddableContentType {
             field1: String
@@ -176,7 +176,7 @@ describe('createContentTypeInput function', () => {
       const { embeddableContentTypes } = parse(schema);
       const input = embeddableContentTypes[0];
 
-      expect(createContentTypeInput(input).apiId).toEqual('CAMEL_CASE_NAME');
+      expect(createContentTypeInput(input).apiId).toEqual('CamelCaseName');
     });
 
     it('generates a label from the name', () => {
@@ -205,7 +205,7 @@ describe('createContentTypeInput function', () => {
       const input = hashmapContentTypes[0];
 
       const output = {
-        apiId: 'COLOR',
+        apiId: 'Color',
         name: 'Color',
         description: 'Test description',
         enumValues: [
@@ -225,7 +225,7 @@ describe('createContentTypeInput function', () => {
       expect(createContentTypeInput(input)).toEqual(output);
     });
 
-    it('uses underscore for multipart camel case names', () => {
+    it('leaves the type name as is', () => {
       const schema = `
         enum CamelCaseName {
           value1 @config(label: "Value 1")
@@ -234,7 +234,7 @@ describe('createContentTypeInput function', () => {
       const { hashmapContentTypes } = parse(schema);
       const input = hashmapContentTypes[0];
 
-      expect(createContentTypeInput(input).apiId).toEqual('CAMEL_CASE_NAME');
+      expect(createContentTypeInput(input).apiId).toEqual('CamelCaseName');
     });
 
     it('generates a label from the name', () => {
@@ -259,7 +259,7 @@ describe('createContentTypeInput function', () => {
       const input = hashmapContentTypes[0];
 
       const output = {
-        apiId: 'COLOR',
+        apiId: 'Color',
         name: 'Color',
         description: '',
         enumValues: [
@@ -285,7 +285,7 @@ describe('createContentTypeInput function', () => {
       const input = hashmapContentTypes[0];
 
       const output = {
-        apiId: 'COLOR',
+        apiId: 'Color',
         name: 'Color',
         description: '',
         enumValues: [

--- a/src/schema/create-field-input.js
+++ b/src/schema/create-field-input.js
@@ -124,9 +124,7 @@ module.exports = function createFieldInput(
 
   let mozaikType = typeMapping.get(graphqlType.type);
   if (!mozaikType) {
-    mozaikType = graphqlType.type
-      .replace(/([a-z])([A-Z])/g, g => `${g[0]}_${g[1]}`)
-      .toUpperCase();
+    mozaikType = graphqlType.type;
   }
 
   if (reservedFieldNames.includes(name.value)) {

--- a/src/schema/create-field-input.test.js
+++ b/src/schema/create-field-input.test.js
@@ -25,7 +25,7 @@ describe('createFieldInput function', () => {
       expect(createFieldInput(input)).toEqual(output);
     });
 
-    it('converts the user type to an uppercased name', () => {
+    it('leaves a custom type name as is', () => {
       const schema = `
         type FeaturedPost implements SimpleContentType {
           title: String
@@ -43,7 +43,7 @@ describe('createFieldInput function', () => {
         label: 'Post',
         apiId: 'post',
         description: '',
-        type: 'FEATURED_POST',
+        type: 'FeaturedPost',
         hasMultipleValues: false,
         validations: [],
       };
@@ -104,7 +104,7 @@ describe('createFieldInput function', () => {
     });
   });
 
-  it('converts the user type to an uppercased name', () => {
+  it('leaves a custom type name as is', () => {
     const schema = `
       type FeaturedPost implements SimpleContentType {
         title: String
@@ -122,7 +122,7 @@ describe('createFieldInput function', () => {
       label: 'Comments',
       apiId: 'comments',
       description: '',
-      type: 'FEATURED_POST_COMMENT',
+      type: 'FeaturedPostComment',
       hasMultipleValues: true,
       validations: [],
     };


### PR DESCRIPTION
We decided not to convert the type names to UPPERCASE_WITH_UNDERSCORES format,
so when we generate the schema from the database we can use the api id as the
type name. The function we used is unable to create a one-to-one mapping.